### PR TITLE
Increased timeout for requests against ChirpStack application server

### DIFF
--- a/src/services/chirpstack/generic-chirpstack-configuration.service.ts
+++ b/src/services/chirpstack/generic-chirpstack-configuration.service.ts
@@ -30,23 +30,23 @@ export class GenericChirpstackConfigurationService {
     private readonly innerLogger = new Logger(GenericChirpstackConfigurationService.name);
 
     setupHeader(endPoint: string, limit?: number, offset?: number): HeaderDto {
-        if (limit != null && offset != null) {
-            const headerDto: HeaderDto = {
-                url: `${this.baseUrl}/api/${endPoint}${
-                    endPoint.indexOf("?") >= 0 ? "&" : "?"
-                }limit=${limit}&offset=${offset}`,
-                timeout: 3000,
-                authorizationType: AuthorizationType.HEADER_BASED_AUTHORIZATION,
-                authorizationHeader: "Bearer " + JwtToken.setupToken(),
-            };
-            return headerDto;
+        // Default timeout value in ms
+        const timeout = 30000;
+        let url = this.baseUrl + "/api/" + endPoint;
+
+        // If limits are supplied, add these as query params
+        if (limit != null && offset != null) {            
+            url += `${endPoint.indexOf("?") >= 0 ? "&" : "?"
+                }limit=${limit}&offset=${offset}`;
         }
-        const headerDto: HeaderDto = {
-            url: this.baseUrl + "/api/" + endPoint,
-            timeout: 3000,
+        
+        let headerDto: HeaderDto = {
+            url,
+            timeout,
             authorizationType: AuthorizationType.HEADER_BASED_AUTHORIZATION,
             authorizationHeader: "Bearer " + JwtToken.setupToken(),
         };
+
         return headerDto;
     }
 


### PR DESCRIPTION
The timeout for calls against the ChirpStack application server has been increased from 3 seconds to 30 seconds. 

This should fix the issue with organizations showing inconsistently in the gateway list. The issue occurs when the API requested data for multiple gateways from the ChirpStack application server REST API and the calls time out before the Application Server can respond. 

I suspect multiple other frontend-issues are related to this. We will look into optimizing the access while fixing these other issues.

Fixes OS2iot/Os2IoT-frontend#45

