### PR TITLE
Pass copies of data to untrusted code instead of references

### DIFF
--- a/src/loaders/nestjs.ts
+++ b/src/loaders/nestjs.ts
@@ -35,7 +35,7 @@ export async function setupNestJs(
     app.use(cookieParser());
 
     BuiltInLogger.log(
-        `Kafka: ${process.env.KAFKA_HOSTNAME || "host.docker.internal"}:${
+        `Kafka: ${process.env.KAFKA_HOSTNAME || "localhost"}:${
             process.env.KAFKA_PORT || "9092"
         }`
     );

--- a/src/services/chirpstack/generic-chirpstack-configuration.service.ts
+++ b/src/services/chirpstack/generic-chirpstack-configuration.service.ts
@@ -19,7 +19,7 @@ import { JwtToken } from "./jwt-token";
 @Injectable()
 export class GenericChirpstackConfigurationService {
     baseUrl = `http://${
-        process.env.CHIRPSTACK_APPLICATION_SERVER_HOSTNAME || "host.docker.internal"
+        process.env.CHIRPSTACK_APPLICATION_SERVER_HOSTNAME || "localhost"
     }:${process.env.CHIRPSTACK_APPLICATION_SERVER_PORT || "8080"}`;
 
     networkServer = `${

--- a/src/services/data-management/payload-decoder-executor.service.ts
+++ b/src/services/data-management/payload-decoder-executor.service.ts
@@ -24,11 +24,16 @@ export class PayloadDecoderExecutorService {
         rawPayload: JSON
     ): string {
         const vm2Logger = new Logger(`${PayloadDecoderExecutorService.name}-VM2`);
+        
+        // Make copies of inputs to untrusted code to avoid unintended side effects if the code chooses to modify these
+        const iotDeviceCopy = JSON.parse(JSON.stringify(iotDevice));
+        const payloadCopy = JSON.parse(JSON.stringify(rawPayload));
+        
         const vm = new VM({
             timeout: 5000,
             sandbox: {
-                innerIotDevice: iotDevice,
-                innerPayload: rawPayload,
+                innerIotDevice: iotDeviceCopy,
+                innerPayload: payloadCopy,
                 log(data: any): void {
                     vm2Logger.debug(data);
                 },

--- a/src/services/kafka/kafka.service.ts
+++ b/src/services/kafka/kafka.service.ts
@@ -30,7 +30,7 @@ export class KafkaService implements OnModuleInit, OnModuleDestroy {
         const kafkaConfig = {
             clientId: process.env.KAFKA_CLIENTID || "os2iot-client",
             brokers: [
-                `${process.env.KAFKA_HOSTNAME || "host.docker.internal"}:${
+                `${process.env.KAFKA_HOSTNAME || "localhost"}:${
                     process.env.KAFKA_PORT || "9093"
                 }`,
             ],


### PR DESCRIPTION
If decoders modified the incoming payload instead of returning a new object it has possible to affect the incoming data to other data targets.

fixes #121 