### PR TITLE
Fix roles in controllers where it was set on the whole class

### DIFF
--- a/src/controllers/admin-controller/chirpstack/chirpstack-gateway.controller.ts
+++ b/src/controllers/admin-controller/chirpstack/chirpstack-gateway.controller.ts
@@ -40,7 +40,6 @@ import { ComposeAuthGuard } from "@auth/compose-auth.guard";
 @Controller("chirpstack/gateway")
 @UseGuards(ComposeAuthGuard, RolesGuard)
 @ApiBearerAuth()
-@Write()
 export class ChirpstackGatewayController {
     constructor(private chirpstackGatewayService: ChirpstackGatewayService) {}
 
@@ -48,6 +47,7 @@ export class ChirpstackGatewayController {
     @ApiProduces("application/json")
     @ApiOperation({ summary: "Create a new Chirpstack Gateway" })
     @ApiBadRequestResponse()
+    @Write()
     async create(
         @Req() req: AuthenticatedRequest,
         @Body() dto: CreateGatewayDto
@@ -97,6 +97,7 @@ export class ChirpstackGatewayController {
     @Get(":gatewayId")
     @ApiProduces("application/json")
     @ApiOperation({ summary: "List all Chirpstack gateways" })
+    @Read()
     async getOne(
         @Param("gatewayId") gatewayId: string
     ): Promise<SingleGatewayResponseDto> {
@@ -115,6 +116,7 @@ export class ChirpstackGatewayController {
     @ApiProduces("application/json")
     @ApiOperation({ summary: "Create a new Chirpstack Gateway" })
     @ApiBadRequestResponse()
+    @Write()
     async update(
         @Req() req: AuthenticatedRequest,
         @Param("gatewayId") gatewayId: string,
@@ -150,6 +152,7 @@ export class ChirpstackGatewayController {
     }
 
     @Delete(":gatewayId")
+    @Write()
     async delete(
         @Req() req: AuthenticatedRequest,
         @Param("gatewayId") gatewayId: string

--- a/src/controllers/admin-controller/chirpstack/device-profile.controller.ts
+++ b/src/controllers/admin-controller/chirpstack/device-profile.controller.ts
@@ -43,7 +43,6 @@ import { ComposeAuthGuard } from "@auth/compose-auth.guard";
 @Controller("chirpstack/device-profiles")
 @UseGuards(ComposeAuthGuard, RolesGuard)
 @ApiBearerAuth()
-@Write()
 export class DeviceProfileController {
     constructor(private deviceProfileService: DeviceProfileService) {}
 

--- a/src/controllers/admin-controller/chirpstack/service-profile.controller.ts
+++ b/src/controllers/admin-controller/chirpstack/service-profile.controller.ts
@@ -42,7 +42,6 @@ import { AuthenticatedRequest } from "@dto/internal/authenticated-request";
 @Controller("chirpstack/service-profiles")
 @UseGuards(ComposeAuthGuard, RolesGuard)
 @ApiBearerAuth()
-@Write()
 export class ServiceProfileController {
     constructor(private serviceProfileService: ServiceProfileService) {}
     private readonly logger = new Logger(ServiceProfileController.name);


### PR DESCRIPTION
Before, any role requirement set in a controller at class-level didn't have any effect. [This PR](https://github.com/OS2iot/OS2IoT-backend/pull/136) fixed this.
This PR is about setting the roles properly for the affected controllers. Looking through the controllers, I only found the chirpstack gateway endpoint to be affected. If a user with only read permissions tried to access the page before, they would get 401. The changes here address this.

The current implementation of roles has the role guard set on each endpoint take priority. I.e. if the gateway controller has `@Write` on a class-level but `@Read` on a POST-endpoint (say, `create()`), then only `@Read` is evaluated.