### PR TITLE
FIWARE datatarget

### DIFF
--- a/src/entities/dto/create-data-target.dto.ts
+++ b/src/entities/dto/create-data-target.dto.ts
@@ -23,6 +23,12 @@ export class CreateDataTargetDto {
     @MaxLength(50)
     name: string;
 
+    @ApiProperty({ required: false, default: "" })
+    tenant: string;
+
+    @ApiProperty({ required: false, default: "", example: null })
+    context: string;
+
     @ApiProperty({ required: true, example: 1 })
     @IsNumber()
     @Min(1)
@@ -35,7 +41,7 @@ export class CreateDataTargetDto {
     @IsString()
     @MaxLength(1024)
     @IsNotBlank("url")
-    @IsUrl()
+    @IsUrl({ require_tld: false, require_protocol: true})
     url: string;
 
     @ApiProperty({ required: true, example: 30000 })

--- a/src/entities/enum/data-target-type-mapping.ts
+++ b/src/entities/enum/data-target-type-mapping.ts
@@ -1,6 +1,9 @@
 import { HttpPushDataTarget } from "@entities/http-push-data-target.entity";
+import { FiwareDataTarget } from "@entities/fiware-data-target.entity";
 import { DataTargetType } from "@enum/data-target-type.enum";
 
 export const dataTargetTypeMap = {
     [DataTargetType.HttpPush]: HttpPushDataTarget,
+    [DataTargetType.Fiware]: FiwareDataTarget,
+
 };

--- a/src/entities/enum/data-target-type.enum.ts
+++ b/src/entities/enum/data-target-type.enum.ts
@@ -1,3 +1,4 @@
 export enum DataTargetType {
     HttpPush = "HTTP_PUSH",
+    Fiware = "FIWARE",
 }

--- a/src/entities/fiware-data-target.entity.ts
+++ b/src/entities/fiware-data-target.entity.ts
@@ -24,10 +24,7 @@ export class FiwareDataTarget extends DataTarget {
     context: string;
 
     @BeforeInsert()
-    private beforeInsert() {
-        /**
-         * Generate uuid (version 4 = random) to be used as the apiKey for this GenericHTTPDevice
-         */
+    private beforeInsert() {       
         this.type = DataTargetType.Fiware;
     }
 

--- a/src/entities/fiware-data-target.entity.ts
+++ b/src/entities/fiware-data-target.entity.ts
@@ -1,0 +1,47 @@
+import { BeforeInsert, ChildEntity, Column } from "typeorm";
+
+import { DataTarget } from "@entities/data-target.entity";
+import { AuthorizationType } from "@enum/authorization-type.enum";
+import { DataTargetType } from "@enum/data-target-type.enum";
+
+import { FiwareDataTargetConfiguration } from "./interfaces/fiware-data-target-configuration.interface";
+
+@ChildEntity(DataTargetType.Fiware)
+export class FiwareDataTarget extends DataTarget {
+    @Column()
+    url: string; 
+
+    @Column({ default: 30000, comment: "HTTP call timeout in milliseconds" })
+    timeout: number;
+
+    @Column({ nullable: true })
+    authorizationHeader?: string;
+
+    @Column({ nullable: true })
+    tenant: string;
+
+    @Column({ nullable: true })
+    context: string;
+
+    @BeforeInsert()
+    private beforeInsert() {
+        /**
+         * Generate uuid (version 4 = random) to be used as the apiKey for this GenericHTTPDevice
+         */
+        this.type = DataTargetType.Fiware;
+    }
+
+    toConfiguration(): FiwareDataTargetConfiguration {
+        return {
+            url: this.url,
+            timeout: this.timeout,
+            authorizationType:
+                this.authorizationHeader != ""
+                    ? AuthorizationType.HEADER_BASED_AUTHORIZATION
+                    : AuthorizationType.NO_AUTHORIZATION,
+            authorizationHeader: this.authorizationHeader,
+            tenant: this.tenant,
+            context: this.context
+        };
+    }
+}

--- a/src/entities/interfaces/fiware-data-target-configuration.interface.ts
+++ b/src/entities/interfaces/fiware-data-target-configuration.interface.ts
@@ -1,0 +1,12 @@
+import { AuthorizationType } from "@enum/authorization-type.enum";
+
+export interface FiwareDataTargetConfiguration {
+    url: string;
+    timeout: number;
+    authorizationType: AuthorizationType;
+    username?: string;
+    password?: string;
+    authorizationHeader?: string;
+    tenant?: string;
+    context?: string;
+}

--- a/src/migration/1644874601012-fiware-data-target.ts
+++ b/src/migration/1644874601012-fiware-data-target.ts
@@ -1,0 +1,26 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class fiwareDataTarget1644874601012 implements MigrationInterface {
+    name = 'fiwareDataTarget1644874601012'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "data_target" ADD "tenant" character varying`);
+        await queryRunner.query(`ALTER TABLE "data_target" ADD "context" character varying`);
+        await queryRunner.query(`ALTER TYPE "public"."data_target_type_enum" RENAME TO "data_target_type_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "data_target_type_enum" AS ENUM('HTTP_PUSH', 'FIWARE')`);
+        await queryRunner.query(`ALTER TABLE "data_target" ALTER COLUMN "type" TYPE "data_target_type_enum" USING "type"::"text"::"data_target_type_enum"`);
+        await queryRunner.query(`DROP TYPE "data_target_type_enum_old"`);
+        await queryRunner.query(`COMMENT ON COLUMN "data_target"."type" IS NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`COMMENT ON COLUMN "data_target"."type" IS NULL`);
+        await queryRunner.query(`CREATE TYPE "data_target_type_enum_old" AS ENUM('HTTP_PUSH')`);
+        await queryRunner.query(`ALTER TABLE "data_target" ALTER COLUMN "type" TYPE "data_target_type_enum_old" USING "type"::"text"::"data_target_type_enum_old"`);
+        await queryRunner.query(`DROP TYPE "data_target_type_enum"`);
+        await queryRunner.query(`ALTER TYPE "data_target_type_enum_old" RENAME TO  "data_target_type_enum"`);
+        await queryRunner.query(`ALTER TABLE "data_target" DROP COLUMN "context"`);
+        await queryRunner.query(`ALTER TABLE "data_target" DROP COLUMN "tenant"`);
+    }
+
+}

--- a/src/modules/data-target/data-target-fiware-sender.module.ts
+++ b/src/modules/data-target/data-target-fiware-sender.module.ts
@@ -1,0 +1,11 @@
+import { HttpModule, Module } from "@nestjs/common";
+
+import { FiwareDataTargetService } from "@services/data-targets/fiware-data-target.service";
+
+@Module({
+    imports: [HttpModule],
+    providers: [FiwareDataTargetService],
+    exports: [FiwareDataTargetService],
+})
+
+export class DataTargetFiwareSenderModule {}

--- a/src/modules/data-target/data-target-kafka.module.ts
+++ b/src/modules/data-target/data-target-kafka.module.ts
@@ -10,6 +10,7 @@ import { IoTDeviceModule } from "@modules/device-management/iot-device.module";
 import { KafkaModule } from "@modules/kafka.module";
 import { SharedModule } from "@modules/shared.module";
 import { DataTargetKafkaListenerService } from "@services/data-targets/data-target-kafka-listener.service";
+import { DataTargetFiwareSenderModule } from "./data-target-fiware-sender.module";
 
 @Module({
     imports: [
@@ -17,6 +18,7 @@ import { DataTargetKafkaListenerService } from "@services/data-targets/data-targ
         HttpModule,
         KafkaModule,
         DataTargetSenderModule,
+        DataTargetFiwareSenderModule,
         DeviceIntegrationPersistenceModule,
         IoTDeviceModule,
         ChirpstackAdministrationModule,

--- a/src/modules/shared.module.ts
+++ b/src/modules/shared.module.ts
@@ -6,6 +6,7 @@ import { DataTarget } from "@entities/data-target.entity";
 import { GenericHTTPDevice } from "@entities/generic-http-device.entity";
 import { GlobalAdminPermission } from "@entities/global-admin-permission.entity";
 import { HttpPushDataTarget } from "@entities/http-push-data-target.entity";
+import { FiwareDataTarget } from "@entities/fiware-data-target.entity";
 import { IoTDevicePayloadDecoderDataTargetConnection } from "@entities/iot-device-payload-decoder-data-target-connection.entity";
 import { IoTDevice } from "@entities/iot-device.entity";
 import { LoRaWANDevice } from "@entities/lorawan-device.entity";
@@ -39,6 +40,7 @@ import { LorawanMulticastDefinition } from "@entities/lorawan-multicast.entity";
             GenericHTTPDevice,
             GlobalAdminPermission,
             HttpPushDataTarget,
+            FiwareDataTarget,
             IoTDevice,
             IoTDevicePayloadDecoderDataTargetConnection,
             DeviceModel,

--- a/src/services/data-targets/data-target-kafka-listener.service.ts
+++ b/src/services/data-targets/data-target-kafka-listener.service.ts
@@ -86,10 +86,10 @@ export class DataTargetKafkaListenerService extends AbstractKafkaConsumer {
             } else if (target.type == DataTargetType.Fiware) {
                 try {
                     const status = await this.fiwareDataTargetService.send(target, dto);
-                    this.logger.debug(`Sent to HttpPush target: ${JSON.stringify(status)}`);
+                    this.logger.debug(`Sent to FIWARE target: ${JSON.stringify(status)}`);
                 } catch (err) {
                     this.logger.error(
-                        `Error while sending to Http Push DataTarget: ${err}`
+                        `Error while sending to FIWARE DataTarget: ${err}`
                     );
                 }
             } else

--- a/src/services/data-targets/data-target.service.ts
+++ b/src/services/data-targets/data-target.service.ts
@@ -230,18 +230,17 @@ export class DataTargetService {
         dataTarget: DataTarget
     ) {
         if (dataTargetDto.type === DataTargetType.HttpPush) {
-            (dataTarget as HttpPushDataTarget).url = dataTargetDto.url;
-            (dataTarget as HttpPushDataTarget).timeout = dataTargetDto.timeout;
-            (dataTarget as HttpPushDataTarget).authorizationHeader =
-                dataTargetDto.authorizationHeader;
+            const httpPushDataTarget = (dataTarget as HttpPushDataTarget);
+            httpPushDataTarget.url = dataTargetDto.url;
+            httpPushDataTarget.timeout = dataTargetDto.timeout;
+            httpPushDataTarget.authorizationHeader = dataTargetDto.authorizationHeader;
         } else if (dataTargetDto.type === DataTargetType.Fiware) {
-            (dataTarget as FiwareDataTarget).url = dataTargetDto.url;
-            (dataTarget as FiwareDataTarget).timeout = dataTargetDto.timeout;
-            (dataTarget as FiwareDataTarget).authorizationHeader =
-                dataTargetDto.authorizationHeader;
-            (dataTarget as FiwareDataTarget).tenant = dataTargetDto.tenant;
-            (dataTarget as FiwareDataTarget).context = dataTargetDto.context;
-
+            const fiwareDataTarget = (dataTarget as FiwareDataTarget);
+            fiwareDataTarget.url = dataTargetDto.url;
+            fiwareDataTarget.timeout = dataTargetDto.timeout;
+            fiwareDataTarget.authorizationHeader = dataTargetDto.authorizationHeader;
+            fiwareDataTarget.tenant = dataTargetDto.tenant;
+            fiwareDataTarget.context = dataTargetDto.context;
         }
     }
 

--- a/src/services/data-targets/fiware-data-target.service.ts
+++ b/src/services/data-targets/fiware-data-target.service.ts
@@ -27,12 +27,12 @@ export class FiwareDataTargetService extends BaseDataTargetService {
 
       
         // Setup HTTP client
-        const axiosConfig = this.makeAxiosConfiguration(config,dto);
+        const axiosConfig = this.makeAxiosConfiguration(config);
 
         const rawBody: string = JSON.stringify(dto.payload);      
 
         const endpointUrl = `${config.url}/ngsi-ld/v1/entityOperations/upsert/`;
-        const target = `HttpTarget(${endpointUrl})`;
+        const target = `FiwareDataTarget(${endpointUrl})`;
 
         try {
             const result = await this.httpService
@@ -40,7 +40,7 @@ export class FiwareDataTargetService extends BaseDataTargetService {
                 .toPromise();
 
             this.logger.debug(
-                `HttpPushDataTarget result: '${JSON.stringify(result.data)}'`
+                `FiwareDataTarget result: '${JSON.stringify(result.data)}'`
             );
             if (!result.status.toString().startsWith("2")) {
                 this.logger.warn(
@@ -50,16 +50,14 @@ export class FiwareDataTargetService extends BaseDataTargetService {
                 );
             }
             return this.success(target);
-        } catch (err) {
-            // TODO: Error handling for common errors
-            this.logger.error(`HttpPushDataTarget got error: ${err}`);
+        } catch (err) {            
+            this.logger.error(`FiwareDataTarget got error: ${err}`);
             return this.failure(target, err);
         }
     }
 
      makeAxiosConfiguration(
-        config: FiwareDataTargetConfiguration,
-        data: TransformedPayloadDto
+        config: FiwareDataTargetConfiguration
     ): AxiosRequestConfig {
         
         const axiosConfig: AxiosRequestConfig = {
@@ -67,8 +65,7 @@ export class FiwareDataTargetService extends BaseDataTargetService {
             headers: this.getHeaders(config),
         };
 
-        if (
-            config.authorizationType !== null &&
+        if (config.authorizationType !== null &&
             config.authorizationType !== AuthorizationType.NO_AUTHORIZATION
         ) {
             if (config.authorizationType === AuthorizationType.HTTP_BASIC_AUTHORIZATION) {

--- a/src/services/data-targets/http-push-data-target.service.ts
+++ b/src/services/data-targets/http-push-data-target.service.ts
@@ -1,6 +1,5 @@
 import { HttpService, Injectable, Logger } from "@nestjs/common";
 import { AxiosRequestConfig } from "axios";
-
 import { AuthorizationType } from "@enum/authorization-type.enum";
 import { DataTarget } from "@entities/data-target.entity";
 import { HttpPushDataTarget } from "@entities/http-push-data-target.entity";

--- a/src/services/device-management/application.service.ts
+++ b/src/services/device-management/application.service.ts
@@ -31,7 +31,7 @@ export class ApplicationService {
         private chirpstackDeviceService: ChirpstackDeviceService,
         @Inject(forwardRef(() => PermissionService))
         private permissionService: PermissionService
-    ) {}
+    ) { }
 
     async findAndCountInList(
         query?: ListAllEntitiesDto,
@@ -65,9 +65,9 @@ export class ApplicationService {
             where:
                 organizationIds.length > 0
                     ? [
-                          { id: In(allowedApplications) },
-                          { belongsTo: In(organizationIds) },
-                      ]
+                        { id: In(allowedApplications) },
+                        { belongsTo: In(organizationIds) },
+                    ]
                     : { id: In(allowedApplications) },
             take: query.limit,
             skip: query.offset,

--- a/test/unit/fiware-data-target.service.spec.ts
+++ b/test/unit/fiware-data-target.service.spec.ts
@@ -1,0 +1,55 @@
+import { HttpService } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { AuthorizationType } from "@enum/authorization-type.enum";
+import { HttpPushDataTargetConfiguration } from "@interfaces/http-push-data-target-configuration.interface";
+import { HttpPushDataTargetData } from "@interfaces/http-push-data-target-data.interface";
+import { FiwareDataTargetService } from "@services/data-targets/fiware-data-target.service";
+
+describe("FiwareDataTargetService", () => {
+    let service: FiwareDataTargetService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FiwareDataTargetService,
+                {
+                    provide: HttpService,
+                    useValue: {
+                        post: jest.fn().mockResolvedValue([{}]),
+                    },
+                },
+            ],
+        }).compile();
+
+        service = module.get<FiwareDataTargetService>(FiwareDataTargetService);
+    });
+
+    it("should be defined", () => {
+        expect(service).toBeDefined();
+    });
+
+    it("makeAxiosConfiguration - translate config and data", () => {
+        const config: HttpPushDataTargetConfiguration = {
+            url: "http://example.com/endpoint",
+            timeout: 1337,
+            authorizationType: AuthorizationType.HEADER_BASED_AUTHORIZATION,
+            authorizationHeader: "Bearer AbCdEf123456",
+        };
+        const data: HttpPushDataTargetData = {
+            rawBody: '{"some_key": "some_value"}',
+            mimeType: "application/json",
+            context: ""
+        };
+
+        const res = FiwareDataTargetService.makeAxiosConfiguration(config, data);
+
+        expect(res).toMatchObject({
+            timeout: 1337,
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: "Bearer AbCdEf123456",
+            },
+        });
+    });
+});


### PR DESCRIPTION
This PR extends the list of supported datatarget types with integration to the FIWARE NGSI-LD Context Brokers. 

- DataTargetType enum is extended with FIWARE option
- DataTargetKafkaListenerService recognizes datatarget type and invokes send function of a corresponding service
- New FiwareDataTarget entity and changes in DataTargetService (CRUD)

The change was developed and tested with the Scorpio Context Broker.