### PR TITLE
Fix applications sorting

### DIFF
--- a/src/entities/dto/list-all-applications.dto.ts
+++ b/src/entities/dto/list-all-applications.dto.ts
@@ -1,11 +1,15 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 
 import { ListAllEntitiesDto } from "@dto/list-all-entities.dto";
+import { StringToNumber } from "@helpers/string-to-number-validator";
+import { IsSwaggerOptional } from "@helpers/optional-validator";
 
 export class ListAllApplicationsDto extends ListAllEntitiesDto {
-    @ApiPropertyOptional({ description: "Filter to one organization" })
+    @IsSwaggerOptional({ description: "Filter to one organization" })
+    @StringToNumber()
     organizationId?: number;
 
-    @ApiPropertyOptional({ description: "Filter to one permission" })
+    @IsSwaggerOptional({ description: "Filter to one permission" })
+    @StringToNumber()
     permissionId?: number;
 }

--- a/src/services/device-management/application.service.ts
+++ b/src/services/device-management/application.service.ts
@@ -42,6 +42,7 @@ export class ApplicationService {
         whitelist?: number[],
         allFromOrgs?: number[]
     ): Promise<ListAllApplicationsResponseDto> {
+        const sorting = this.getSortingForApplications(query);
         const orgCondition =
             allFromOrgs != null
                 ? { id: In(whitelist), belongsTo: In(allFromOrgs) }
@@ -51,7 +52,7 @@ export class ApplicationService {
             take: query.limit,
             skip: query.offset,
             relations: ["iotDevices"],
-            order: { id: query.sort },
+            order: sorting,
         });
 
         return {
@@ -89,17 +90,7 @@ export class ApplicationService {
         query?: ListAllEntitiesDto,
         allowedOrganisations?: number[]
     ): Promise<ListAllApplicationsResponseDto> {
-        const sorting: { [id: string]: string | number } = {};
-        if (
-            query.orderOn != null &&
-            (query.orderOn == "id" ||
-                query.orderOn == "name" ||
-                query.orderOn == "updatedAt")
-        ) {
-            sorting[query.orderOn] = query.sort.toLocaleUpperCase();
-        } else {
-            sorting["id"] = "ASC";
-        }
+        const sorting = this.getSortingForApplications(query);
         const [result, total] = await this.applicationRepository.findAndCount({
             where:
                 allowedOrganisations != null
@@ -439,5 +430,19 @@ export class ApplicationService {
             }
         }
         return orderBy;
+    }
+
+    private getSortingForApplications(query: ListAllEntitiesDto): Record<string, string | number> {
+        const sorting: Record<string, string | number> = {};
+        if (query.orderOn != null &&
+            (query.orderOn == "id" ||
+                query.orderOn == "name" ||
+                query.orderOn == "updatedAt")) {
+            sorting[query.orderOn] = query.sort.toLocaleUpperCase();
+        }
+        else {
+            sorting["id"] = "ASC";
+        }
+        return sorting;
     }
 }


### PR DESCRIPTION
Applications were not sorted by name unless you were a global admin. This was for two reasons:
- The organization (and permission) id were not converted to a number
- If the user isn't an admin, sorting is only applied on the application id