### PR TITLE
Allow null numbers and validate them correctly

### DIFF
--- a/src/config/constants/pagination-constants.ts
+++ b/src/config/constants/pagination-constants.ts
@@ -1,0 +1,2 @@
+export const DefaultLimit = 100;
+export const DefaultOffset = 0;

--- a/src/entities/dto/list-all-applications.dto.ts
+++ b/src/entities/dto/list-all-applications.dto.ts
@@ -1,10 +1,18 @@
-import { ApiPropertyOptional } from "@nestjs/swagger";
-
+import { DefaultLimit, DefaultOffset } from "@config/constants/pagination-constants";
 import { ListAllEntitiesDto } from "@dto/list-all-entities.dto";
-import { StringToNumber } from "@helpers/string-to-number-validator";
 import { IsSwaggerOptional } from "@helpers/optional-validator";
+import {
+    NullableStringToNumber,
+    StringToNumber,
+} from "@helpers/string-to-number-validator";
+import { ApiProperty, OmitType } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsOptional } from "class-validator";
 
-export class ListAllApplicationsDto extends ListAllEntitiesDto {
+export class ListAllApplicationsDto extends OmitType(ListAllEntitiesDto, [
+    "limit",
+    "offset",
+]) {
     @IsSwaggerOptional({ description: "Filter to one organization" })
     @StringToNumber()
     organizationId?: number;
@@ -12,4 +20,14 @@ export class ListAllApplicationsDto extends ListAllEntitiesDto {
     @IsSwaggerOptional({ description: "Filter to one permission" })
     @StringToNumber()
     permissionId?: number;
+
+    @ApiProperty({ type: Number, required: false })
+    @IsOptional()
+    @Transform(({ value }) => NullableStringToNumber(value))
+    limit? = DefaultLimit;
+
+    @ApiProperty({ type: Number, required: false })
+    @IsOptional()
+    @Transform(({ value }) => NullableStringToNumber(value))
+    offset? = DefaultOffset;
 }

--- a/src/entities/dto/list-all-applications.dto.ts
+++ b/src/entities/dto/list-all-applications.dto.ts
@@ -7,7 +7,7 @@ import {
 } from "@helpers/string-to-number-validator";
 import { ApiProperty, OmitType } from "@nestjs/swagger";
 import { Transform } from "class-transformer";
-import { IsOptional } from "class-validator";
+import { IsOptional, IsNumber } from "class-validator";
 
 export class ListAllApplicationsDto extends OmitType(ListAllEntitiesDto, [
     "limit",
@@ -23,11 +23,13 @@ export class ListAllApplicationsDto extends OmitType(ListAllEntitiesDto, [
 
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
+    @IsNumber()
     @Transform(({ value }) => NullableStringToNumber(value))
     limit? = DefaultLimit;
 
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
+    @IsNumber()
     @Transform(({ value }) => NullableStringToNumber(value))
     offset? = DefaultOffset;
 }

--- a/src/entities/dto/list-all-entities.dto.ts
+++ b/src/entities/dto/list-all-entities.dto.ts
@@ -1,3 +1,4 @@
+import { DefaultLimit, DefaultOffset } from "@config/constants/pagination-constants";
 import { StringToNumber } from "@helpers/string-to-number-validator";
 import { ApiProperty } from "@nestjs/swagger";
 import { IsOptional, IsString } from "class-validator";
@@ -5,12 +6,12 @@ import { IsOptional, IsString } from "class-validator";
 export class ListAllEntitiesDto {
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
-    @StringToNumber({ allowNulls: true })
-    limit? = 100;
+    @StringToNumber()
+    limit? = DefaultLimit;
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
-    @StringToNumber({ allowNulls: true })
-    offset? = 0;
+    @StringToNumber()
+    offset? = DefaultOffset;
     @ApiProperty({ type: String, required: false })
     @IsOptional()
     @IsString()

--- a/src/entities/dto/list-all-entities.dto.ts
+++ b/src/entities/dto/list-all-entities.dto.ts
@@ -5,11 +5,11 @@ import { IsOptional, IsString } from "class-validator";
 export class ListAllEntitiesDto {
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
-    @StringToNumber()
+    @StringToNumber({ allowNulls: true })
     limit? = 100;
     @ApiProperty({ type: Number, required: false })
     @IsOptional()
-    @StringToNumber()
+    @StringToNumber({ allowNulls: true })
     offset? = 0;
     @ApiProperty({ type: String, required: false })
     @IsOptional()

--- a/src/helpers/string-to-number-validator.ts
+++ b/src/helpers/string-to-number-validator.ts
@@ -1,14 +1,37 @@
-import { Type } from "class-transformer";
-import { IsNumber } from "class-validator";
+import { Transform, Type } from "class-transformer";
+import { isNumber, registerDecorator, ValidationOptions } from "class-validator";
 
 /**
  * Checks if a value can be converted to a number
  */
-export const StringToNumber = (): PropertyDecorator => {
-    return (propertyValue: unknown, propertyName: string): void => {
-        // Cast the value to a number
-        Type(() => Number)(propertyValue, propertyName);
-        // Validate whether the value is a number
-        IsNumber()(propertyValue, propertyName);
+export function StringToNumber(
+    validationOptions?: ValidationOptions & {
+        allowNulls: boolean;
+    }
+) {
+    return function (object: unknown, propertyName: string): void {
+        registerDecorator({
+            name: "stringToNumber",
+            target: object.constructor,
+            propertyName: propertyName,
+            constraints: [],
+            options: validationOptions,
+            validator: {
+                validate(value: unknown) {
+                    if (
+                        validationOptions?.allowNulls &&
+                        (value === null || value === "null")
+                    ) {
+                        // Force value to null. This mutates the value which exists only inside class-transformer.
+                        Transform(() => null)(object, propertyName);
+                        return true;
+                    }
+
+                    // Cast the value to a number, mutating it for the next operations, and validate it
+                    Type(() => Number)(object, propertyName);
+                    return isNumber(Number(value));
+                },
+            },
+        });
     };
-};
+}

--- a/src/helpers/string-to-number-validator.ts
+++ b/src/helpers/string-to-number-validator.ts
@@ -1,37 +1,28 @@
-import { Transform, Type } from "class-transformer";
-import { isNumber, registerDecorator, ValidationOptions } from "class-validator";
+import { Type } from "class-transformer";
+import { IsNumber } from "class-validator";
 
 /**
  * Checks if a value can be converted to a number
  */
-export function StringToNumber(
-    validationOptions?: ValidationOptions & {
-        allowNulls: boolean;
-    }
-) {
-    return function (object: unknown, propertyName: string): void {
-        registerDecorator({
-            name: "stringToNumber",
-            target: object.constructor,
-            propertyName: propertyName,
-            constraints: [],
-            options: validationOptions,
-            validator: {
-                validate(value: unknown) {
-                    if (
-                        validationOptions?.allowNulls &&
-                        (value === null || value === "null")
-                    ) {
-                        // Force value to null. This mutates the value which exists only inside class-transformer.
-                        Transform(() => null)(object, propertyName);
-                        return true;
-                    }
-
-                    // Cast the value to a number, mutating it for the next operations, and validate it
-                    Type(() => Number)(object, propertyName);
-                    return isNumber(Number(value));
-                },
-            },
-        });
+export const StringToNumber = (): PropertyDecorator => {
+    return (propertyValue: unknown, propertyName: string): void => {
+        // Cast the value to a number
+        Type(() => Number)(propertyValue, propertyName);
+        // Validate whether the value is a number
+        IsNumber()(propertyValue, propertyName);
     };
-}
+};
+
+/**
+ * Fixes unexpected behaviour when casting using @Type() decorator. When casting a query parameter using
+ * Type() or Transform() from class-transformer, all parameters with the same decorator are casted.
+ * That's unexpected behaviour.
+ * @param value
+ */
+export const NullableStringToNumber = (value: unknown): number | null => {
+    if (value === null || value === "null") {
+        return null;
+    }
+
+    return Number(value);
+};


### PR DESCRIPTION
This is a supplementary fix to [this PR](https://github.com/OS2iot/OS2IoT-frontend/pull/106).

The issue with the `class-transformer` library is that it mutates the parameter deeply inside a private property. We need to default its value if none is passed; otherwise. it must be validated and sanitized.

In cases with editing a payload decoder, we want to fetch all applications. This PR updates the check by allowing null or "null" values, if it has been explicitly allowed. If it's allowed, then the decorator doesn't force it to a number if `null` or "null" is passed.