### PR TITLE
bug: set ssl from env

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -11,5 +11,6 @@ module.exports = {
     "migrations": ["src/migration/*.ts"],
     "cli": {
         "migrationsDir": "src/migration"
-    }
+    },
+    "ssl": process.env.DATABASE_ENABLE_SSL === "true"
 }


### PR DESCRIPTION
Set SSL for TypeORM from the environment variable. Test by setting 

`DATABASE_ENABLE_SSL: true`

as an environment variable in the "os2iot-backend" resource in the root docker compose file. See [here](https://github.com/OS2iot/OS2IoT-docker/blob/master/docker-compose.yml#L68). Then delete any existing backend container and run
`docker-compose up os2iot-backend -d`

Fixes https://github.com/OS2iot/OS2IoT-backend/issues/191