### PR TITLE
Bugfix/iot 1581 gateway deleted mismatch

### DIFF
--- a/src/entities/dto/chirpstack/gateway-contents.dto.ts
+++ b/src/entities/dto/chirpstack/gateway-contents.dto.ts
@@ -1,5 +1,5 @@
 import { ApiHideProperty, ApiProperty } from "@nestjs/swagger";
-import { Type } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 import {
   IsEmail,
   IsEnum,
@@ -36,6 +36,7 @@ export class GatewayContentsDto {
   @IsString()
   @IsHexadecimal()
   @Length(16, 16)
+  @Transform(({ value }) => value.toLowerCase())
   gatewayId: string;
 
   @ApiProperty({ required: false })

--- a/src/entities/dto/chirpstack/update-gateway.dto.ts
+++ b/src/entities/dto/chirpstack/update-gateway.dto.ts
@@ -1,10 +1,11 @@
 import { ApiHideProperty, ApiProperty, OmitType } from "@nestjs/swagger";
 import { ValidateNested } from "class-validator";
 import { GatewayContentsDto } from "./gateway-contents.dto";
-import { Type } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 
 export class UpdateGatewayContentsDto extends OmitType(GatewayContentsDto, ["gatewayId"]) {
   @ApiHideProperty()
+  @Transform(({ value }) => value.toLowerCase())
   gatewayId: string;
 
   @ApiHideProperty()

--- a/src/entities/enum/error-codes.enum.ts
+++ b/src/entities/enum/error-codes.enum.ts
@@ -50,4 +50,5 @@ export enum ErrorCodes {
   UserAlreadyInPermission = "MESSAGE.USER-ALREADY-IN-PERMISSION",
   CouldntGetApplications = "MESSAGE.COULD-NOT-GET-CS-APPLICATIONS",
   DifferentServiceProfile = "MESSAGE.DIFFERENT-CREATION-SERVICE-PROFILE",
+  OrganizationCannotBeDeletedHasGateways = "MESSAGE.ORGANIZATION-GATEWAYS-EXISTS",
 }

--- a/src/entities/gateway.entity.ts
+++ b/src/entities/gateway.entity.ts
@@ -1,9 +1,9 @@
 ﻿import { DbBaseEntity } from "@entities/base.entity";
-import { Column, Entity, ManyToOne } from "typeorm";
 import { Organization } from "@entities/organization.entity";
-import { Point } from "geojson";
-import { IsEmail, IsPhoneNumber, Length } from "class-validator";
 import { GatewayPlacement, GatewayStatus } from "@enum/gateway.enum";
+import { Length } from "class-validator";
+import { Point } from "geojson";
+import { Column, Entity, ManyToOne } from "typeorm";
 
 @Entity("gateway")
 export class Gateway extends DbBaseEntity {
@@ -13,7 +13,12 @@ export class Gateway extends DbBaseEntity {
   @Column({ nullable: true })
   description?: string;
 
-  @Column()
+  @Column({
+    transformer: {
+      to: (value: string) => value.toLowerCase(),
+      from: (value: string) => value.toLowerCase(),
+    },
+  })
   @Length(16, 16, { message: "Must be 16 characters" })
   gatewayId: string;
 

--- a/src/services/chirpstack/chirpstack-gateway.service.ts
+++ b/src/services/chirpstack/chirpstack-gateway.service.ts
@@ -89,7 +89,7 @@ export class ChirpstackGatewayService extends GenericChirpstackConfigurationServ
     const getGatewayRequest = new GetGatewayRequest();
     getGatewayRequest.setGatewayId(gateway.gatewayId);
     const existingGateway = await this.get<GetGatewayResponse>("gateways", this.gatewayClient, getGatewayRequest).catch(
-      undefined
+      () => undefined
     );
 
     if (existingGateway)

--- a/src/services/user-management/organization.service.ts
+++ b/src/services/user-management/organization.service.ts
@@ -236,7 +236,12 @@ export class OrganizationService {
   }
 
   async delete(id: number): Promise<DeleteResponseDto> {
-    const res = await this.organizationRepository.delete(id);
+    const dbOrganization = await this.organizationRepository.findOne({ where: { id }, relations: { gateways: true } });
+    if (dbOrganization?.gateways?.length !== 0) {
+      throw new BadRequestException(ErrorCodes.OrganizationCannotBeDeletedHasGateways);
+    }
+
+    const res = await this.organizationRepository.delete(dbOrganization.id);
     if (res.affected == 0) {
       throw new NotFoundException();
     }


### PR DESCRIPTION
Der er løst følgende:
* Organization med eksisterende gateways forsøges at blive slettet, hvilket sletter gateways i db og ikke chirpstack.

* Gateway id er oprettet med uppercase enten i db/gennem api

Ud over dto og db entity transformer decorators, er der også lavet en del gatewayId.tolowerCase - dette er evt redundant ud over ved create. Det skal i hvert fald overvejes om det bliver for rodet, da det ikke er en case der skulle kunne rammes, medmindre der anvendes postman/lignende.
