### PR TITLE
#IoT-1500: Min/Max packages less than or equal receivedPackages: Makes it possible to set 0 as an accepted value.

### DIFF
--- a/src/services/chirpstack/chirpstack-gateway.service.ts
+++ b/src/services/chirpstack/chirpstack-gateway.service.ts
@@ -645,7 +645,7 @@ export class ChirpstackGatewayService extends GenericChirpstackConfigurationServ
 
     const receivedPackages = gatewayStats[0].rxPacketsReceived;
 
-    if (gateway.minimumPackages < receivedPackages && receivedPackages < gateway.maximumPackages) {
+    if (gateway.minimumPackages <= receivedPackages && receivedPackages <= gateway.maximumPackages) {
       return;
     }
 


### PR DESCRIPTION
Tiny correction to #267 