### PR TITLE
Application metadata

### DIFF
--- a/src/entities/application.entity.ts
+++ b/src/entities/application.entity.ts
@@ -116,4 +116,7 @@ export class Application extends DbBaseEntity {
 
   @Column({ nullable: true })
   chirpstackId?: string;
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: JSON;
 }

--- a/src/entities/dto/create-application.dto.ts
+++ b/src/entities/dto/create-application.dto.ts
@@ -7,7 +7,7 @@ import { IsPhoneNumberString } from "@helpers/phone-number.validator";
 import { nameof } from "@helpers/type-helper";
 import { ApiProperty } from "@nestjs/swagger";
 import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsOptional, IsString, MaxLength, MinLength } from "class-validator";
-import { IsMetadataJson } from "@helpers/is-metadata-json.validator";
+import { IsMetadataJsonObject } from "@helpers/is-metadata-json-object.validator";
 
 export class CreateApplicationDto {
   @ApiProperty({ required: true })
@@ -100,6 +100,6 @@ export class CreateApplicationDto {
 
   @ApiProperty({ required: false })
   @IsOptional()
-  @IsMetadataJson(nameof<CreateApplicationDto>("metadata"))
+  @IsMetadataJsonObject(nameof<CreateApplicationDto>("metadata"))
   metadata?: JSON;
 }

--- a/src/entities/dto/create-application.dto.ts
+++ b/src/entities/dto/create-application.dto.ts
@@ -7,6 +7,7 @@ import { IsPhoneNumberString } from "@helpers/phone-number.validator";
 import { nameof } from "@helpers/type-helper";
 import { ApiProperty } from "@nestjs/swagger";
 import { ArrayUnique, IsArray, IsBoolean, IsEnum, IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+import { IsMetadataJson } from "@helpers/is-metadata-json.validator";
 
 export class CreateApplicationDto {
   @ApiProperty({ required: true })
@@ -96,4 +97,9 @@ export class CreateApplicationDto {
   @IsString()
   @MaxLength(1024)
   chirpstackId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsMetadataJson(nameof<CreateApplicationDto>("metadata"))
+  metadata?: JSON;
 }

--- a/src/helpers/is-metadata-json-object.validator.ts
+++ b/src/helpers/is-metadata-json-object.validator.ts
@@ -1,0 +1,55 @@
+import { ErrorCodes } from "@enum/error-codes.enum";
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from "class-validator";
+
+@ValidatorConstraint({ name: "isMetadataJsonObject", async: false })
+export class IsMetadataJsonObjectConstraint implements ValidatorConstraintInterface {
+  private message = "";
+
+  public validate(value: any, args: ValidationArguments): boolean {
+    const [propertyName] = args.constraints;
+    this.message = `${propertyName} must be an object with non-empty string keys and values`;
+
+    if (typeof value !== "object") {
+      return false;
+    }
+    try {
+      for (const key of Object.keys(value)) {
+        if (typeof key !== "string" || key.trim() === "") {
+          this.message = ErrorCodes.InvalidKeyInKeyValuePair;
+          return false;
+        }
+        if (typeof value[key] !== "string" || value[key].trim() === "") {
+          this.message = ErrorCodes.InvalidValueInKeyValuePair;
+          return false;
+        }
+      }
+    } catch (error) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public defaultMessage(_args: ValidationArguments): string {
+    return this.message;
+  }
+}
+
+export function IsMetadataJsonObject(property: string, validationOptions?: ValidationOptions) {
+  return function (object: unknown, propertyName: string): void {
+    registerDecorator({
+      name: "isMetadataJsonObject",
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [property],
+      options: validationOptions,
+      validator: IsMetadataJsonObjectConstraint,
+    });
+  };
+}

--- a/src/migration/1773923548971-add-application-metadata.ts
+++ b/src/migration/1773923548971-add-application-metadata.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddApplicationMetadata1773923548971 implements MigrationInterface {
+    name = 'AddApplicationMetadata1773923548971'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "application" ADD "metadata" jsonb`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "application" DROP COLUMN "metadata"`);
+    }
+
+}

--- a/src/services/device-management/application.service.ts
+++ b/src/services/device-management/application.service.ts
@@ -640,6 +640,7 @@ export class ApplicationService {
     application.personalData = applicationDto.personalData;
     application.hardware = applicationDto.hardware;
     application.permissions = await this.permissionService.findManyByIds(applicationDto.permissionIds);
+    application.metadata = applicationDto.metadata;
 
     // Set metadata dependencies
     application.controlledProperties = applicationDto.controlledProperties


### PR DESCRIPTION
Adds application metadata. See https://github.com/OS2iot/OS2iot-frontend/pull/220 for the matching frontend.

The metadata is essentially the same as used on IoT Devices with one major difference: The application metadata is stored as a JSON object (with string keys and values) in a JSON field.

Metadata for devices is stored in a JSON field as well, but the actual value is a string containing a JSON encoded object, e.g. `"{\\"name\\":\\"Mikkel\\"}"`.