### PR TITLE
Fix OTAA key mapping for LoRaWAN 1.1.x devices

### DIFF
--- a/src/entities/dto/create-lorawan-settings.dto.ts
+++ b/src/entities/dto/create-lorawan-settings.dto.ts
@@ -24,6 +24,14 @@ export class CreateLoRaWANSettingsDto extends PickType(ChirpstackDeviceContentsD
   @IsHexadecimal()
   OTAAapplicationKey?: string;
 
+  /* OTAA — only used for LoRaWAN 1.1.x device profiles (the root NwkKey). */
+  @ApiProperty({ required: false })
+  @ValidateIf((o: CreateLoRaWANSettingsDto) => o.activationType == ActivationType.OTAA && !!o.OTAAnetworkKey)
+  @IsString()
+  @Length(32, 32)
+  @IsHexadecimal()
+  OTAAnetworkKey?: string;
+
   /* ABP */
   @ApiProperty({ required: false })
   @ValidateIf((o: CreateLoRaWANSettingsDto) => o.activationType == ActivationType.ABP)

--- a/src/entities/lorawan-device.entity.ts
+++ b/src/entities/lorawan-device.entity.ts
@@ -15,6 +15,10 @@ export class LoRaWANDevice extends IoTDevice {
   OTAAapplicationKey: string;
 
   @Column({ nullable: true })
+  @Length(32, 32, { message: "Must be 32 characters" })
+  OTAAnetworkKey: string;
+
+  @Column({ nullable: true })
   deviceProfileName: string;
 
   @Column({ nullable: true })

--- a/src/migration/1779744000000-added-otaa-network-key.ts
+++ b/src/migration/1779744000000-added-otaa-network-key.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddedOTAANetworkKey1779744000000 implements MigrationInterface {
+  name = "AddedOTAANetworkKey1779744000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "iot_device" ADD "OTAAnetworkKey" character varying`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "iot_device" DROP COLUMN "OTAAnetworkKey"`);
+  }
+}

--- a/src/services/chirpstack/chirpstack-device.service.ts
+++ b/src/services/chirpstack/chirpstack-device.service.ts
@@ -42,7 +42,7 @@ import {
 } from "@chirpstack/chirpstack-api/api/device_pb";
 import { dateToTimestamp } from "@helpers/date.helper";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
-import { Aggregation } from "@chirpstack/chirpstack-api/common/common_pb";
+import { Aggregation, MacVersion, MacVersionMap } from "@chirpstack/chirpstack-api/common/common_pb";
 import { DeviceMetricsDto, MetricProperties } from "@dto/chirpstack/chirpstack-device-metrics.dto";
 
 @Injectable()
@@ -184,16 +184,21 @@ export class ChirpstackDeviceService extends GenericChirpstackConfigurationServi
     return deviceActivation;
   }
 
-  public async activateDeviceWithOTAA(deviceEUI: string, nwkKey: string, isUpdate: boolean): Promise<boolean> {
+  public async activateDeviceWithOTAA(
+    deviceEUI: string,
+    appKey: string,
+    isUpdate: boolean,
+    macVersion: MacVersionMap[keyof MacVersionMap],
+    networkKey?: string
+  ): Promise<boolean> {
     try {
+      const deviceKeys = this.mapDeviceKeysToChirpstack(deviceEUI, appKey, macVersion, networkKey);
       if (isUpdate) {
         const req = new UpdateDeviceKeysRequest();
-        const deviceKeys = this.mapDeviceKeysToChirpstack(deviceEUI, nwkKey);
         req.setDeviceKeys(deviceKeys);
         await this.putKeys(req);
       } else {
         const req = new CreateDeviceKeysRequest();
-        const deviceKeys = this.mapDeviceKeysToChirpstack(deviceEUI, nwkKey);
         req.setDeviceKeys(deviceKeys);
         await this.postKeys(req);
       }
@@ -204,10 +209,22 @@ export class ChirpstackDeviceService extends GenericChirpstackConfigurationServi
     return true;
   }
 
-  private mapDeviceKeysToChirpstack(deviceEUI: string, nwkKey: string) {
+  private mapDeviceKeysToChirpstack(
+    deviceEUI: string,
+    appKey: string,
+    macVersion: MacVersionMap[keyof MacVersionMap],
+    networkKey?: string
+  ) {
     const deviceKeys = new DeviceKeys();
     deviceKeys.setDevEui(deviceEUI);
-    deviceKeys.setNwkKey(nwkKey);
+    // ChirpStack's DeviceKeys.nwk_key holds the AppKey in LoRaWAN 1.0.x (only one root key)
+    // and the NwkKey in LoRaWAN 1.1.x (where AppKey lives in DeviceKeys.app_key).
+    if (macVersion >= MacVersion.LORAWAN_1_1_0) {
+      deviceKeys.setNwkKey(networkKey ?? appKey);
+      deviceKeys.setAppKey(appKey);
+    } else {
+      deviceKeys.setNwkKey(appKey);
+    }
     return deviceKeys;
   }
 
@@ -328,8 +345,9 @@ export class ChirpstackDeviceService extends GenericChirpstackConfigurationServi
   public async enrichLoRaWANDevice(iotDevice: IoTDevice): Promise<LoRaWANDeviceWithChirpstackDataDto> {
     const loraDevice = iotDevice as LoRaWANDeviceWithChirpstackDataDto;
     loraDevice.lorawanSettings = new CreateLoRaWANSettingsDto();
-    await this.mapActivationAndKeys(loraDevice);
     const csData = await this.getChirpstackDevice(loraDevice.deviceEUI);
+    const deviceProfile = await this.deviceProfileService.findOneDeviceProfileById(csData.deviceProfileID);
+    await this.mapActivationAndKeys(loraDevice, deviceProfile.deviceProfile.macVersion);
     loraDevice.lorawanSettings.devEUI = csData.devEUI;
     loraDevice.lorawanSettings.deviceProfileID = csData.deviceProfileID;
     loraDevice.lorawanSettings.skipFCntCheck = csData.skipFCntCheck;
@@ -337,19 +355,29 @@ export class ChirpstackDeviceService extends GenericChirpstackConfigurationServi
     loraDevice.lorawanSettings.deviceStatusBattery = csData.deviceStatusBattery;
     loraDevice.lorawanSettings.deviceStatusMargin = csData.deviceStatusMargin;
 
-    const deviceProfile = await this.deviceProfileService.findOneDeviceProfileById(csData.deviceProfileID);
     loraDevice.deviceProfileName = deviceProfile.deviceProfile.name;
 
     return loraDevice;
   }
 
-  private async mapActivationAndKeys(loraDevice: LoRaWANDeviceWithChirpstackDataDto) {
+  private async mapActivationAndKeys(
+    loraDevice: LoRaWANDeviceWithChirpstackDataDto,
+    macVersion: MacVersionMap[keyof MacVersionMap]
+  ) {
     const keys = await this.getDeviceKeys(loraDevice.deviceEUI);
     if (keys.nwkKey) {
-      // OTAA
+      // OTAA: in 1.0.x, nwkKey carries the AppKey (only root key); in 1.1.x,
+      // nwkKey is NwkKey and appKey is AppKey.
       loraDevice.lorawanSettings.activationType = ActivationType.OTAA;
-      loraDevice.lorawanSettings.OTAAapplicationKey = keys.nwkKey;
-      loraDevice.OTAAapplicationKey = keys.nwkKey;
+      if (macVersion >= MacVersion.LORAWAN_1_1_0) {
+        loraDevice.lorawanSettings.OTAAnetworkKey = keys.nwkKey;
+        loraDevice.OTAAnetworkKey = keys.nwkKey;
+        loraDevice.lorawanSettings.OTAAapplicationKey = keys.appKey || keys.nwkKey;
+        loraDevice.OTAAapplicationKey = keys.appKey || keys.nwkKey;
+      } else {
+        loraDevice.lorawanSettings.OTAAapplicationKey = keys.nwkKey;
+        loraDevice.OTAAapplicationKey = keys.nwkKey;
+      }
     } else {
       const activation = await this.getDeviceActivation(loraDevice.deviceEUI);
       if (activation.devAddr != null) {

--- a/src/services/csv-generator.service.ts
+++ b/src/services/csv-generator.service.ts
@@ -60,7 +60,8 @@ export class CsvGeneratorService {
       `${lorawanSettings?.deviceProfileID ?? ""},` +
       `${lorawanSettings?.skipFCntCheck ?? ""},` +
       `${lorawanSettings?.activationType ?? ""},` +
-      `${lorawanSettings?.OTAAapplicationKey ?? ""}`;
+      `${lorawanSettings?.OTAAapplicationKey ?? ""},` +
+      `${lorawanSettings?.OTAAnetworkKey ?? ""}`;
 
     return csvRow;
   }
@@ -97,4 +98,5 @@ const csvFields = [
   "skipFCntCheck",
   "activationType",
   "OTAAapplicationKey",
+  "OTAAnetworkKey",
 ];

--- a/src/services/device-management/iot-device.service.ts
+++ b/src/services/device-management/iot-device.service.ts
@@ -1043,10 +1043,16 @@ export class IoTDeviceService {
 
   private async doActivationByOTAA(dto: CreateIoTDeviceDto, isUpdate: boolean) {
     if (dto.lorawanSettings.OTAAapplicationKey) {
+      const profile = await this.deviceProfileService.findOneDeviceProfileById(
+        dto.lorawanSettings.deviceProfileID
+      );
+      const macVersion = profile.deviceProfile.macVersion;
       await this.chirpstackDeviceService.activateDeviceWithOTAA(
         dto.lorawanSettings.devEUI,
         dto.lorawanSettings.OTAAapplicationKey,
-        isUpdate
+        isUpdate,
+        macVersion,
+        dto.lorawanSettings.OTAAnetworkKey
       );
     } else {
       throw new BadRequestException(ErrorCodes.MissingOTAAInfo);


### PR DESCRIPTION
## Problem

For LoRaWAN 1.1.x devices havner brugerens AppKey i ChirpStacks `nwk_key`-felt, og det rigtige `app_key`-felt sættes aldrig. Symptomet er at devices ikke kan joine fordi network- og application-nøglerne reelt er byttet om i ChirpStack.

ChirpStacks `DeviceKeys`-protobuf har versionsafhængig semantik:

| Felt      | LoRaWAN 1.0.x                  | LoRaWAN 1.1.x          |
|-----------|--------------------------------|------------------------|
| `nwk_key` | AppKey (eneste root-nøgle)     | NwkKey (root network)  |
| `app_key` | Ubrugt                         | AppKey (root app)      |

OS2IoT skrev altid `OTAAapplicationKey` ind i `nwk_key` uden at se på device-profilens `macVersion` (`mapDeviceKeysToChirpstack`, `chirpstack-device.service.ts:207`). Læsestien lavede den symmetriske fejl.

## Løsning

* `OTAAnetworkKey` tilføjet til DTO + entity + ny migration (kun udfyldt ved 1.1.x — frontend skjuler feltet ved 1.0.x).
* `mapDeviceKeysToChirpstack` og `activateDeviceWithOTAA` tager nu `macVersion` ind og mapper version-afhængigt. 1.0.x-adfærd uændret.
* `doActivationByOTAA` slår device-profilen op via `DeviceProfileService` og videregiver `macVersion` + begge nøgler.
* `mapActivationAndKeys` udfylder både `OTAAapplicationKey` og `OTAAnetworkKey` for 1.1.x ved læsning.
* CSV import/export schema udvidet med `OTAAnetworkKey`-kolonne.

## Test (manuel, lokal docker-compose)

1. Opret device-profil med `mac_version = 5` (LoRaWAN 1.1.0) og en med `mac_version = 3` (1.0.3).
2. Opret application + to OTAA-devices, ét pr. profil.
3. **1.1.x device**: sæt `OTAAapplicationKey` = `aaaa…aa` og `OTAAnetworkKey` = `bbbb…bb`. Verificer i ChirpStack via gRPC:
   ```
   grpcurl … api.DeviceService/GetKeys
   → nwk_key = bbbb…bb, app_key = aaaa…aa  ✓
   ```
4. **1.0.x device** (regression): sæt kun `OTAAapplicationKey` = `cccc…cc`.
   ```
   → nwk_key = cccc…cc, app_key = 00…00  ✓ (uændret)
   ```
5. GET device tilbage via API → korrekte nøgler i begge felter for 1.1.x.

## Migration af eksisterende data

Migrationen tilføjer kun den nye kolonne. Eksisterende 1.1.x-rækker har brugerens "AppKey" gemt i ChirpStacks `nwk_key`, og `OTAAnetworkKey` på OS2IoT-siden er `NULL`. Næste gang en bruger åbner et 1.1.x device i frontend vil de se nøglen vist i App-feltet + et tomt NwkKey-felt — og kan reprovisionere korrekt. Bevidst valg at lade dette være en bruger-handling fremfor automatisk data-flytning; sig til hvis I foretrækker en data-migration.

## Companion PR

* Frontend: OS2iot/OS2iot-frontend#221 (NwkKey-felt på device-form — afhænger af denne PR)
